### PR TITLE
Setup aiotize design system repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,27 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+# Fonts and binaries
+brand/fonts/*.otf
+brand/fonts/*.ttf
+brand/fonts/*.woff
+brand/fonts/*.woff2
+brand/fonts/*.eot
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Build/preview tools
+node_modules
+dist
+.cache
+
 
 dotnet-bot-illustrations/.DS_Store
 dotnet-bot-illustrations/Wallpapers/.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,25 @@
+MIT License
+
+Copyright (c) 2025 Aiotize Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 CC0 1.0 Universal
 
 Statement of Purpose

--- a/README.md
+++ b/README.md
@@ -1,35 +1,25 @@
-# .NET Brand Guidelines
+## Aiotize Inc. — Design System & Brand Assets
 
-The purpose of these guidelines is to provide a framework for communicating with the .NET developer community and establishing a consistent brand identity. This repo serves as a guide and reference to designers, writers, and developers to create consistent, on-brand content for .NET. 
+This repository stores Aiotize Inc.'s design system, brand assets, and ready‑to‑use templates. It is inspired by the visual language of Perplexity.ai while preserving Aiotize’s distinct `AI` and `AIOTIZE INC.` display marks.
 
-Read the [.NET Brand Guidelines](dotnet-styleGuide-2024.pdf).
+### What’s inside
+- `design-system/`: Design tokens (colors, spacing, typography, motion), component CSS, and theming.
+- `brand/`: Logos, typefaces, color palettes, backgrounds, grids, and usage docs.
+- `docs/`: A static preview site showcasing tokens and components.
+- `templates/`: Simple HTML templates (hero, landing skeleton) using the design system.
 
-## Logo
+### Quick start (no build tools required)
+Open `docs/index.html` in your browser. It references the design tokens and components directly from the repo.
 
-The .NET logo is one of the most simple and direct visual representations of the .NET brand. The .NET logo purple color is #512bd4. Please read the brand guidelines for proper uses of the logo. 
+### Philosophy
+- Keep the `AI` and `AIOTIZE INC.` display wordmark unique to Aiotize.
+- Derive the rest of the system (layout, tone, gradients, controls) from a Perplexity‑like aesthetic: calm oceanic darks, clear contrast, elegant spacing, subtle borders, and smooth motion.
 
-See the [logo](/logo) folder.
+### Adding/Updating brand assets
+- Place final vector logos in `brand/logos/` (keep provided filenames to avoid breaking links in docs).
+- Add licensed font files to `brand/fonts/` and update the `@font-face` blocks in `design-system/tokens.css` and `brand/fonts/README.md`.
+- If you update color tokens in `design-system/tokens.css`, the docs and templates will pick them up automatically.
 
-## Illustrations
-These illustrations are more than sketches, they’re stories full of character, delightful surprises—and layers of meaning, many containing the [dotnet-bot](https://github.com/dotnet-bot). The dotnet-bot represents the community that comes with the .NET brand and platform. Dotnet-bot also helps with checking pull-requests on .NET repos. Please read the brand guidelines for proper uses. 
-
-See the [spot-illustrations](/spot-illustrations) folder.
-
-## Presentation Template
-You can use the presentation template as a starting point for your presentations to the .NET developer community. It contains type, theme colors, and illustrations that follow the brand guidelines. 
-
-See the [presentation-template](/presentation-template) folder.
-
-## Type
-
-The Open Sans typeface helps express the humanity in our voice and personality across all our communications. Open Sans is an open source typeface designed by Steve Matteson, Type Director of Ascender Corp.
-
-You can download it from Google Fonts: [fonts.google.com/specimen/Open+Sans](https://fonts.google.com/specimen/Open+Sans) 
-
-## License
-
-Illustrations in the brand repo are licensed under the very permissive [CC0 1.0 Universal license](https://github.com/dotnet/brand/blob/master/LICENSE). You may use the artwork to create your own .NET swag items to give away at community events, use the presentation template for your presentations, and use the illustrations and logo to represent .NET in related content, per the [.NET Brand Guidelines](dotnet-styleGuide-2024.pdf). 
-
-The .NET brand guidelines and .NET logo are copyright of the .NET authors. 
-
-The photos in the brand guidelines are all from [unsplash](https://unsplash.com) and are released under the [unsplash license](https://unsplash.com/license).
+### Legal & attribution
+- Do not copy Perplexity.ai proprietary marks or copyrighted assets. This repository implements an original theme and tokens inspired by their public aesthetic.
+- All original code in this repository is licensed MIT (see `LICENSE`). Your logos, fonts, and media remain your property under their respective licenses.

--- a/brand/USAGE.md
+++ b/brand/USAGE.md
@@ -1,0 +1,22 @@
+## Brand usage guidelines
+
+### Voice & tone
+- Analytical, calm, confident. Avoid exaggeration.
+
+### Logos
+- Use `aiotize-inc-wordmark.svg` for headers and `ai-monogram.svg` for compact placements.
+- Maintain clear space equal to the cap height of `A` around the mark.
+- Use light text on dark backgrounds and vice‑versa.
+
+### Colors
+- Primary UI: Deep ocean backgrounds with cerulean accents.
+- Avoid overusing accent; reserve for actions and highlights.
+
+### Typography
+- Display: `Aiotize Display`.
+- UI: `Inter`.
+- Tracking: Slight positive letter spacing for large titles.
+
+### Motion
+- Ease out, short durations. Avoid bouncy spring effects.
+

--- a/brand/backgrounds/gradient-hero.svg
+++ b/brand/backgrounds/gradient-hero.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+  <defs>
+    <radialGradient id="g1" cx="85%" cy="85%" r="60%">
+      <stop offset="0%" stop-color="#2ea1ff" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#2ea1ff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="g2" cx="5%" cy="10%" r="55%">
+      <stop offset="0%" stop-color="#59c7ff" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#59c7ff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0b1c23"/>
+      <stop offset="30%" stop-color="#0e232b"/>
+      <stop offset="100%" stop-color="#132c35"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <ellipse cx="1360" cy="765" rx="720" ry="420" fill="url(#g1)"/>
+  <ellipse cx="80" cy="90" rx="540" ry="360" fill="url(#g2)"/>
+</svg>
+

--- a/brand/colors/palette.json
+++ b/brand/colors/palette.json
@@ -1,0 +1,21 @@
+{
+  "name": "Aiotize Oceanic",
+  "version": 1,
+  "colors": {
+    "bg": "#0e232b",
+    "bg2": "#0b1c23",
+    "surface": "#142c35",
+    "surface2": "#183743",
+    "surface3": "#1e4654",
+    "border": "#244552",
+    "text": "#e8f3f7",
+    "textMuted": "#a4bac1",
+    "accent": "#59c7ff",
+    "accentStrong": "#2ea1ff",
+    "accentSoft": "#b9ecff",
+    "positive": "#28c08e",
+    "warning": "#f5a623",
+    "danger": "#ff5d6e"
+  }
+}
+

--- a/brand/fonts/README.md
+++ b/brand/fonts/README.md
@@ -1,0 +1,10 @@
+## Fonts
+
+Add licensed font files here and keep their licenses alongside. Suggested families:
+
+- `Aiotize Display` (custom wordmark type) — used for `AI` and `AIOTIZE INC.` marks and display headings.
+- `Inter` — primary UI sans (variable preferred).
+- `Space Grotesk` — optional secondary display.
+
+After adding, update source URLs in `design-system/tokens.css` `@font-face` rules.
+

--- a/brand/grids/8px-grid.svg
+++ b/brand/grids/8px-grid.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <pattern id="grid8" width="8" height="8" patternUnits="userSpaceOnUse">
+      <path d="M8 0H0V8" fill="none" stroke="#5e9fb5" stroke-opacity="0.25"/>
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grid8)"/>
+</svg>
+

--- a/brand/logos/README.md
+++ b/brand/logos/README.md
@@ -1,0 +1,13 @@
+## Logos
+
+Place final vector and raster logos here:
+
+- `aiotize-inc-wordmark.svg` — Full wordmark `AIOTIZE INC.` using Aiotize Display
+- `ai-monogram.svg` — Monogram `AI`
+- `favicon.svg` / `favicon.png`
+
+Guidelines:
+- Maintain clear space equal to the cap height of the `A` around all sides.
+- Minimum sizes: Wordmark 120px width digital; Monogram 24px square.
+- Do not alter letterforms or tracking. Colors should follow `brand/colors/palette.json`.
+

--- a/brand/logos/ai-monogram.svg
+++ b/brand/logos/ai-monogram.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#b9ecff"/>
+      <stop offset="100%" stop-color="#2ea1ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="320" rx="40" fill="#0e232b"/>
+  <path d="M40 220 L128 80 h64 v160 h-40 V120 l-56 100z" fill="url(#g)"/>
+  <rect x="224" y="80" width="40" height="160" fill="#e8f3f7" rx="8"/>
+  <rect x="264" y="80" width="16" height="40" fill="#59c7ff" rx="4"/>
+</svg>
+

--- a/brand/logos/aiotize-inc-wordmark.svg
+++ b/brand/logos/aiotize-inc-wordmark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 320">
+  <defs>
+    <style>
+      @font-face {
+        font-family: 'Aiotize Display';
+        src: local('Aiotize Display');
+        font-weight: 700;
+        font-style: normal;
+      }
+      .wordmark { font: 700 140px 'Aiotize Display', 'Space Grotesk', system-ui; letter-spacing: .12em; fill: #e8f3f7; }
+    </style>
+  </defs>
+  <rect width="1600" height="320" fill="#0e232b"/>
+  <text x="80" y="210" class="wordmark">AIOTIZE INC.</text>
+</svg>
+

--- a/brand/logos/favicon.svg
+++ b/brand/logos/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#59c7ff"/>
+      <stop offset="100%" stop-color="#2ea1ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0e232b"/>
+  <path d="M10 40 L24 20 h8 v24 h-6 V28 l-8 12z" fill="url(#g)"/>
+  <path d="M42 20 v24 h6 V20z" fill="#e8f3f7"/>
+  <path d="M48 26 v-6 h6 v6z" fill="#59c7ff"/>
+</svg>
+

--- a/design-system/components.css
+++ b/design-system/components.css
@@ -1,0 +1,99 @@
+/* Aiotize Inc. — Component styles built on tokens.css */
+
+/* Reset */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  color: var(--color-text);
+  background: var(--color-bg);
+  font-family: var(--font-sans);
+  font-size: var(--text-md);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Utilities */
+.container { max-width: var(--container-max); padding: 0 var(--container-pad); margin: 0 auto; }
+.stack > * + * { margin-top: var(--space-6); }
+.row { display: flex; gap: var(--grid-gap); flex-wrap: wrap; }
+.col { flex: 1 1 0; min-width: 260px; }
+.muted { color: var(--color-text-muted); }
+.surface { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+.surface-2 { background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+.bordered { border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+
+/* Typography */
+.display { font-family: var(--font-display); font-weight: 700; letter-spacing: 0.01em; }
+h1, h2, h3 { font-family: var(--font-display); margin: 0 0 var(--space-4); line-height: 1.2; }
+h1 { font-size: var(--text-4xl); }
+h2 { font-size: var(--text-3xl); }
+h3 { font-size: var(--text-2xl); }
+p { margin: 0 0 var(--space-5); }
+
+/* Links */
+a { color: var(--color-accent); text-decoration: none; }
+a:hover { color: var(--color-accent-strong); text-decoration: underline; }
+
+/* Buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 10px; padding: 10px 16px;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  transition: background var(--dur-base) var(--ease-out), transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.btn:hover { background: var(--color-surface-3); box-shadow: var(--shadow-1); }
+.btn:active { transform: translateY(1px); }
+.btn:focus-visible { outline: none; box-shadow: var(--ring); }
+.btn-primary { background: linear-gradient(180deg, var(--color-accent), var(--color-accent-strong)); color: #001319; border-color: rgba(0,0,0,0.15); }
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-ghost { background: transparent; border-color: var(--color-border); }
+
+/* Inputs */
+.input, .select, .textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: var(--radius-sm);
+  transition: border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.input::placeholder { color: var(--color-text-muted); }
+.input:focus, .select:focus, .textarea:focus { outline: none; border-color: var(--color-accent); box-shadow: var(--ring); }
+
+/* Card */
+.card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-7); box-shadow: var(--shadow-1); }
+.card:hover { transform: translateY(-1px); transition: transform var(--dur-base) var(--ease-out); }
+
+/* Tag */
+.tag { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: var(--radius-pill); border: 1px solid var(--color-border); background: var(--color-surface-2); font-size: var(--text-sm); }
+
+/* Nav */
+.nav { position: sticky; top: 0; z-index: 50; background: rgba(14,35,43,0.6); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+.nav .inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-family: var(--font-display); font-weight: 800; letter-spacing: 0.06em; }
+.brand img { height: 22px; }
+
+/* Hero */
+.hero { background: var(--gradient-hero); padding: 80px 0; border-bottom: 1px solid var(--color-border); }
+.hero h1 { font-size: var(--text-5xl); margin-bottom: var(--space-4); }
+.hero p { font-size: var(--text-lg); color: var(--color-text-muted); }
+
+/* Grid overlay (for design reviews) */
+.grid-overlay { pointer-events: none; position: fixed; inset: 0; background-size: 8px 8px, 8px 8px; background-image: linear-gradient(to right, rgba(94,159,181,.12) 1px, transparent 1px), linear-gradient(to bottom, rgba(94,159,181,.12) 1px, transparent 1px); opacity: 0; transition: opacity var(--dur-base) var(--ease-out); z-index: 1000; }
+.grid-overlay.active { opacity: .75; }
+
+/* Tables */
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--color-border); }
+
+/* Code */
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+pre { padding: var(--space-6); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-sm); overflow: auto; }
+

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,0 +1,125 @@
+/*
+  Aiotize Inc. — Design Tokens
+  Inspired by Perplexity-like calm, oceanic dark UI with crisp contrast.
+  Keep `AI` and `AIOTIZE INC.` display marks as-is; other tokens are adaptable.
+*/
+
+/* Font faces (replace sources with licensed files in brand/fonts) */
+/* Example placeholders. Update URLs when you add real fonts. */
+@font-face {
+  font-family: "Aiotize Display";
+  src: local("Aiotize Display"), url("../brand/fonts/AiotizeDisplay.woff2") format("woff2");
+  font-weight: 400 800;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Inter";
+  src: local("Inter"), url("../brand/fonts/InterVariable.woff2") format("woff2-variations");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Space Grotesk";
+  src: local("Space Grotesk"), url("../brand/fonts/SpaceGrotesk-Variable.woff2") format("woff2-variations");
+  font-weight: 300 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  /* Color palette (Dark as default) */
+  --color-bg: #0e232b;           /* deep ocean */
+  --color-bg-2: #0b1c23;         /* page root */
+  --color-surface: #142c35;      /* cards, surfaces */
+  --color-surface-2: #183743;    /* elevated surfaces */
+  --color-surface-3: #1e4654;    /* hover surfaces */
+  --color-border: #244552;
+  --color-text: #e8f3f7;
+  --color-text-muted: #a4bac1;
+  --color-accent: #59c7ff;       /* cerulean */
+  --color-accent-strong: #2ea1ff;
+  --color-accent-soft: #b9ecff;
+  --color-positive: #28c08e;
+  --color-warning: #f5a623;
+  --color-danger: #ff5d6e;
+
+  /* Gradient tokens */
+  --gradient-hero: radial-gradient(1200px 700px at 85% 85%, rgba(46,161,255,0.35), transparent 60%),
+                   radial-gradient(900px 600px at 5% 10%, rgba(89,199,255,0.28), transparent 55%),
+                   linear-gradient(180deg, #0b1c23 0%, #0e232b 30%, #132c35 100%);
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-display: "Aiotize Display", "Space Grotesk", var(--font-sans);
+
+  /* Type scale (approx 1.2 modular) */
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-md: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 30px;
+  --text-4xl: 36px;
+  --text-5xl: 48px;
+  --text-6xl: 60px;
+
+  /* Spacing (4px base) */
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 8px;
+  --space-4: 12px;
+  --space-5: 16px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 40px;
+  --space-9: 48px;
+  --space-10: 64px;
+
+  /* Radii */
+  --radius-xs: 6px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.28);
+  --shadow-2: 0 6px 24px rgba(0,0,0,0.36);
+  --ring: 0 0 0 2px rgba(46,161,255,0.4);
+
+  /* Motion */
+  --ease-out: cubic-bezier(.17,.67,.29,1);
+  --ease-in: cubic-bezier(.48,.04,.52,.96);
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 320ms;
+
+  /* Layout */
+  --container-max: 1200px;
+  --container-pad: 24px;
+  --grid-gap: 16px;
+}
+
+/* Light theme */
+:root[data-theme="light"] {
+  --color-bg: #f7fbfd;
+  --color-bg-2: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-2: #f2f7fa;
+  --color-surface-3: #e8f2f7;
+  --color-border: #dbe7ee;
+  --color-text: #0b1c23;
+  --color-text-muted: #4d6872;
+  --color-accent: #2ea1ff;
+  --color-accent-strong: #007be6;
+  --color-accent-soft: #cdeeff;
+  --gradient-hero: radial-gradient(1200px 700px at 85% 85%, rgba(0,123,230,0.12), transparent 60%),
+                   radial-gradient(900px 600px at 5% 10%, rgba(46,161,255,0.18), transparent 55%),
+                   linear-gradient(180deg, #ffffff 0%, #f7fbfd 60%, #eef6fa 100%);
+}
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+## Docs
+
+Open `index.html` in any browser to preview tokens and components. No build step required.
+

--- a/docs/brand/colors/palette.json
+++ b/docs/brand/colors/palette.json
@@ -1,0 +1,21 @@
+{
+  "name": "Aiotize Oceanic",
+  "version": 1,
+  "colors": {
+    "bg": "#0e232b",
+    "bg2": "#0b1c23",
+    "surface": "#142c35",
+    "surface2": "#183743",
+    "surface3": "#1e4654",
+    "border": "#244552",
+    "text": "#e8f3f7",
+    "textMuted": "#a4bac1",
+    "accent": "#59c7ff",
+    "accentStrong": "#2ea1ff",
+    "accentSoft": "#b9ecff",
+    "positive": "#28c08e",
+    "warning": "#f5a623",
+    "danger": "#ff5d6e"
+  }
+}
+

--- a/docs/brand/logos/favicon.svg
+++ b/docs/brand/logos/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#59c7ff"/>
+      <stop offset="100%" stop-color="#2ea1ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0e232b"/>
+  <path d="M10 40 L24 20 h8 v24 h-6 V28 l-8 12z" fill="url(#g)"/>
+  <path d="M42 20 v24 h6 V20z" fill="#e8f3f7"/>
+  <path d="M48 26 v-6 h6 v6z" fill="#59c7ff"/>
+</svg>
+

--- a/docs/design-system/components.css
+++ b/docs/design-system/components.css
@@ -1,0 +1,73 @@
+/* Copied components for self-contained docs hosting */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  color: var(--color-text);
+  background: var(--color-bg);
+  font-family: var(--font-sans);
+  font-size: var(--text-md);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.container { max-width: var(--container-max); padding: 0 var(--container-pad); margin: 0 auto; }
+.stack > * + * { margin-top: var(--space-6); }
+.row { display: flex; gap: var(--grid-gap); flex-wrap: wrap; }
+.col { flex: 1 1 0; min-width: 260px; }
+.muted { color: var(--color-text-muted); }
+.surface { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+.surface-2 { background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+.bordered { border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+.display { font-family: var(--font-display); font-weight: 700; letter-spacing: 0.01em; }
+h1, h2, h3 { font-family: var(--font-display); margin: 0 0 var(--space-4); line-height: 1.2; }
+h1 { font-size: var(--text-4xl); }
+h2 { font-size: var(--text-3xl); }
+h3 { font-size: var(--text-2xl); }
+p { margin: 0 0 var(--space-5); }
+a { color: var(--color-accent); text-decoration: none; }
+a:hover { color: var(--color-accent-strong); text-decoration: underline; }
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 10px; padding: 10px 16px;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  transition: background var(--dur-base) var(--ease-out), transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.btn:hover { background: var(--color-surface-3); box-shadow: var(--shadow-1); }
+.btn:active { transform: translateY(1px); }
+.btn:focus-visible { outline: none; box-shadow: var(--ring); }
+.btn-primary { background: linear-gradient(180deg, var(--color-accent), var(--color-accent-strong)); color: #001319; border-color: rgba(0,0,0,0.15); }
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-ghost { background: transparent; border-color: var(--color-border); }
+.input, .select, .textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: var(--radius-sm);
+  transition: border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.input::placeholder { color: var(--color-text-muted); }
+.input:focus, .select:focus, .textarea:focus { outline: none; border-color: var(--color-accent); box-shadow: var(--ring); }
+.card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-7); box-shadow: var(--shadow-1); }
+.card:hover { transform: translateY(-1px); transition: transform var(--dur-base) var(--ease-out); }
+.tag { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: var(--radius-pill); border: 1px solid var(--color-border); background: var(--color-surface-2); font-size: var(--text-sm); }
+.nav { position: sticky; top: 0; z-index: 50; background: rgba(14,35,43,0.6); backdrop-filter: blur(8px); border-bottom: 1px solid var(--color-border); }
+.nav .inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-family: var(--font-display); font-weight: 800; letter-spacing: 0.06em; }
+.brand img { height: 22px; }
+.hero { background: var(--gradient-hero); padding: 80px 0; border-bottom: 1px solid var(--color-border); }
+.hero h1 { font-size: var(--text-5xl); margin-bottom: var(--space-4); }
+.hero p { font-size: var(--text-lg); color: var(--color-text-muted); }
+.grid-overlay { pointer-events: none; position: fixed; inset: 0; background-size: 8px 8px, 8px 8px; background-image: linear-gradient(to right, rgba(94,159,181,.12) 1px, transparent 1px), linear-gradient(to bottom, rgba(94,159,181,.12) 1px, transparent 1px); opacity: 0; transition: opacity var(--dur-base) var(--ease-out); z-index: 1000; }
+.grid-overlay.active { opacity: .75; }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--color-border); }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+pre { padding: var(--space-6); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-sm); overflow: auto; }
+

--- a/docs/design-system/tokens.css
+++ b/docs/design-system/tokens.css
@@ -1,0 +1,110 @@
+/* Copied tokens for self-contained docs hosting */
+@font-face {
+  font-family: "Aiotize Display";
+  src: local("Aiotize Display"), url("../brand/fonts/AiotizeDisplay.woff2") format("woff2");
+  font-weight: 400 800;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Inter";
+  src: local("Inter"), url("../brand/fonts/InterVariable.woff2") format("woff2-variations");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Space Grotesk";
+  src: local("Space Grotesk"), url("../brand/fonts/SpaceGrotesk-Variable.woff2") format("woff2-variations");
+  font-weight: 300 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  --color-bg: #0e232b;
+  --color-bg-2: #0b1c23;
+  --color-surface: #142c35;
+  --color-surface-2: #183743;
+  --color-surface-3: #1e4654;
+  --color-border: #244552;
+  --color-text: #e8f3f7;
+  --color-text-muted: #a4bac1;
+  --color-accent: #59c7ff;
+  --color-accent-strong: #2ea1ff;
+  --color-accent-soft: #b9ecff;
+  --color-positive: #28c08e;
+  --color-warning: #f5a623;
+  --color-danger: #ff5d6e;
+
+  --gradient-hero: radial-gradient(1200px 700px at 85% 85%, rgba(46,161,255,0.35), transparent 60%),
+                   radial-gradient(900px 600px at 5% 10%, rgba(89,199,255,0.28), transparent 55%),
+                   linear-gradient(180deg, #0b1c23 0%, #0e232b 30%, #132c35 100%);
+
+  --font-sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-display: "Aiotize Display", "Space Grotesk", var(--font-sans);
+
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-md: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 30px;
+  --text-4xl: 36px;
+  --text-5xl: 48px;
+  --text-6xl: 60px;
+
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 8px;
+  --space-4: 12px;
+  --space-5: 16px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 40px;
+  --space-9: 48px;
+  --space-10: 64px;
+
+  --radius-xs: 6px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --radius-pill: 999px;
+
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.28);
+  --shadow-2: 0 6px 24px rgba(0,0,0,0.36);
+  --ring: 0 0 0 2px rgba(46,161,255,0.4);
+
+  --ease-out: cubic-bezier(.17,.67,.29,1);
+  --ease-in: cubic-bezier(.48,.04,.52,.96);
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 320ms;
+
+  --container-max: 1200px;
+  --container-pad: 24px;
+  --grid-gap: 16px;
+}
+
+:root[data-theme="light"] {
+  --color-bg: #f7fbfd;
+  --color-bg-2: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-2: #f2f7fa;
+  --color-surface-3: #e8f2f7;
+  --color-border: #dbe7ee;
+  --color-text: #0b1c23;
+  --color-text-muted: #4d6872;
+  --color-accent: #2ea1ff;
+  --color-accent-strong: #007be6;
+  --color-accent-soft: #cdeeff;
+  --gradient-hero: radial-gradient(1200px 700px at 85% 85%, rgba(0,123,230,0.12), transparent 60%),
+                   radial-gradient(900px 600px at 5% 10%, rgba(46,161,255,0.18), transparent 55%),
+                   linear-gradient(180deg, #ffffff 0%, #f7fbfd 60%, #eef6fa 100%);
+}
+
+@import url("../../design-system/tokens.css");
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aiotize Design System</title>
+    <link rel="icon" href="./brand/logos/favicon.svg" />
+    <link rel="stylesheet" href="./design-system/tokens.css" />
+    <link rel="stylesheet" href="./design-system/components.css" />
+    <style>
+      .swatch { width: 120px; height: 72px; border-radius: var(--radius-sm); border: 1px solid var(--color-border); }
+      .swatches { display:grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
+      .k { font-size: var(--text-sm); color: var(--color-text-muted); }
+      .tokens { display:grid; grid-template-columns: 220px 1fr; gap: 12px; }
+      .footer { color: var(--color-text-muted); padding: 40px 0; text-align:center; }
+      .wordmark { font-family: var(--font-display); font-weight: 800; letter-spacing: 0.08em; font-size: var(--text-3xl); }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+      .preview-surface { background: var(--color-surface); border-radius: var(--radius-lg); border: 1px solid var(--color-border); padding: 16px; }
+    </style>
+  </head>
+  <body>
+    <header class="nav">
+      <div class="container inner">
+        <div class="brand"><img src="./brand/logos/favicon.svg" alt="AI" /><span>AIOTIZE INC.</span></div>
+        <div style="display:flex; align-items:center; gap: 10px;">
+          <button id="theme-toggle" class="btn btn-ghost">Toggle theme</button>
+          <button id="grid-toggle" class="btn btn-ghost">Grid</button>
+        </div>
+      </div>
+    </header>
+    <div class="grid-overlay" id="grid"></div>
+
+    <main>
+      <section class="hero">
+        <div class="container">
+          <div class="wordmark">AIOTIZE INC.</div>
+          <h1 class="display">Design System</h1>
+          <p class="muted">Tokens, components, and brand assets inspired by a Perplexity‑like aesthetic.</p>
+          <div style="margin-top: var(--space-6); display:flex; gap:12px;">
+            <a class="btn btn-primary" href="./templates/landing.html">View Landing Template</a>
+            <a class="btn btn-ghost" href="./brand/colors/palette.json">Color JSON</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="container stack" style="padding: 40px 0 60px;">
+        <h2>Colors</h2>
+        <div class="swatches">
+          <div>
+            <div class="swatch" style="background: var(--color-bg);"></div>
+            <div class="k">bg</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-surface);"></div>
+            <div class="k">surface</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-accent);"></div>
+            <div class="k">accent</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-accent-strong);"></div>
+            <div class="k">accent-strong</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-positive);"></div>
+            <div class="k">positive</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-warning);"></div>
+            <div class="k">warning</div>
+          </div>
+          <div>
+            <div class="swatch" style="background: var(--color-danger);"></div>
+            <div class="k">danger</div>
+          </div>
+        </div>
+
+        <h2>Typography</h2>
+        <div class="stack">
+          <div class="display" style="font-size: var(--text-5xl);">Display 5xl — Aiotize Display</div>
+          <div style="font-size: var(--text-xl);">Body XL — Inter</div>
+          <div class="muted">Muted text example</div>
+        </div>
+
+        <h2>Components</h2>
+        <div class="row">
+          <div class="col">
+            <div class="card">
+              <h3>Buttons</h3>
+              <div style="display:flex; gap: 12px; flex-wrap: wrap;">
+                <button class="btn btn-primary">Primary</button>
+                <button class="btn">Default</button>
+                <button class="btn btn-ghost">Ghost</button>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card">
+              <h3>Inputs</h3>
+              <div class="stack">
+                <input class="input" placeholder="Search" />
+                <textarea class="textarea" rows="3" placeholder="Message"></textarea>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card">
+              <h3>Tags</h3>
+              <div class="stack">
+                <span class="tag">AI</span>
+                <span class="tag">Drones</span>
+                <span class="tag">Automation</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <h2>Code Sample</h2>
+        <div class="preview-surface">
+<pre><code class="mono">&lt;link rel="stylesheet" href="/design-system/tokens.css" /&gt;
+&lt;link rel="stylesheet" href="/design-system/components.css" /&gt;
+
+&lt;button class="btn btn-primary"&gt;Primary&lt;/button&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">© 2025 Aiotize Inc. · Design System</div>
+    </footer>
+
+    <script>
+      const grid = document.getElementById('grid');
+      document.getElementById('grid-toggle').addEventListener('click', () => {
+        grid.classList.toggle('active');
+      });
+      const toggle = document.getElementById('theme-toggle');
+      toggle.addEventListener('click', () => {
+        const root = document.documentElement;
+        const isLight = root.getAttribute('data-theme') === 'light';
+        root.setAttribute('data-theme', isLight ? 'dark' : 'light');
+      });
+    </script>
+  </body>
+  
+</html>
+

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aiotize — Landing Template</title>
+    <link rel="icon" href="../brand/logos/favicon.svg" />
+    <link rel="stylesheet" href="../design-system/tokens.css" />
+    <link rel="stylesheet" href="../design-system/components.css" />
+    <style>
+      .hero-landing { background: var(--gradient-hero); padding: 120px 0 80px; }
+      .feature { display: grid; grid-template-columns: 1.2fr 1fr; gap: var(--space-8); align-items: center; }
+      @media (max-width: 900px) { .feature { grid-template-columns: 1fr; } }
+      .img-demo { aspect-ratio: 16/10; border-radius: var(--radius-lg); border: 1px solid var(--color-border); background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(0,0,0,.08)); box-shadow: var(--shadow-1); }
+    </style>
+  </head>
+  <body>
+    <header class="nav">
+      <div class="container inner">
+        <div class="brand"><img src="../brand/logos/favicon.svg" alt="AI" /><span>AIOTIZE INC.</span></div>
+        <nav class="row" style="gap:18px;">
+          <a href="../index.html">Docs</a>
+          <a href="#">Guidelines</a>
+          <a href="#">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero hero-landing">
+        <div class="container">
+          <h1 class="display">Automation & Intelligence for the Physical World</h1>
+          <p class="muted" style="max-width: 720px;">Deep‑tech platform combining AI and autonomous drones to unlock real‑time automation and business intelligence for enterprises.</p>
+          <div style="margin-top: var(--space-7); display:flex; gap:12px;">
+            <a class="btn btn-primary" href="#">Request demo</a>
+            <a class="btn btn-ghost" href="#">Explore platform</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="container stack" style="padding: 60px 0;">
+        <div class="feature">
+          <div>
+            <h2>Adaptive Insight</h2>
+            <p class="muted">Unified knowledge interface, grounded on your enterprise data and live operations.</p>
+            <div style="margin-top: var(--space-6);">
+              <span class="tag">Context aware</span>
+              <span class="tag" style="margin-left:8px;">Secure by design</span>
+            </div>
+          </div>
+          <div class="img-demo"></div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=./docs/index.html">
+<title>Aiotize Design System</title>
+<a href="./docs/index.html">Go to Docs</a>
+

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aiotize — Landing Template</title>
+    <link rel="icon" href="../brand/logos/favicon.svg" />
+    <link rel="stylesheet" href="../design-system/tokens.css" />
+    <link rel="stylesheet" href="../design-system/components.css" />
+    <style>
+      .hero-landing { background: var(--gradient-hero); padding: 120px 0 80px; }
+      .feature { display: grid; grid-template-columns: 1.2fr 1fr; gap: var(--space-8); align-items: center; }
+      @media (max-width: 900px) { .feature { grid-template-columns: 1fr; } }
+      .img-demo { aspect-ratio: 16/10; border-radius: var(--radius-lg); border: 1px solid var(--color-border); background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(0,0,0,.08)); box-shadow: var(--shadow-1); }
+    </style>
+  </head>
+  <body>
+    <header class="nav">
+      <div class="container inner">
+        <div class="brand"><img src="../brand/logos/favicon.svg" alt="AI" /><span>AIOTIZE INC.</span></div>
+        <nav class="row" style="gap:18px;">
+          <a href="#">Docs</a>
+          <a href="#">Guidelines</a>
+          <a href="#">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero hero-landing">
+        <div class="container">
+          <h1 class="display">Automation & Intelligence for the Physical World</h1>
+          <p class="muted" style="max-width: 720px;">Deep‑tech platform combining AI and autonomous drones to unlock real‑time automation and business intelligence for enterprises.</p>
+          <div style="margin-top: var(--space-7); display:flex; gap:12px;">
+            <a class="btn btn-primary" href="#">Request demo</a>
+            <a class="btn btn-ghost" href="#">Explore platform</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="container stack" style="padding: 60px 0;">
+        <div class="feature">
+          <div>
+            <h2>Adaptive Insight</h2>
+            <p class="muted">Unified knowledge interface, grounded on your enterprise data and live operations.</p>
+            <div style="margin-top: var(--space-6);">
+              <span class="tag">Context aware</span>
+              <span class="tag" style="margin-left:8px;">Secure by design</span>
+            </div>
+          </div>
+          <div class="img-demo"></div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>
+


### PR DESCRIPTION
This repo is maintained by the .NET authors. Please submit PRs to contribute your own designs and artwork to the community via the .NET Foundation swag repo here: [dotnet-foundation/swag](https://github.com/dotnet-foundation/swag).

This PR scaffolds a new repository for Aiotize Inc.'s design system and brand assets.

The changes establish a central source for:
- **Design System:** Core CSS tokens (colors, spacing, typography, motion) and components (buttons, inputs, cards, navigation) inspired by Perplexity.ai's aesthetic.
- **Brand Assets:** Placeholder logos, color palettes, backgrounds, grids, and font guidelines, while preserving Aiotize's distinct "AI" and "AIOTIZE INC." display typeface.
- **Documentation:** A self-contained `docs/` site for easy preview and GitHub Pages deployment, including a basic landing page template.

This setup provides a foundational, immediately viewable design system to guide Aiotize's visual identity.

---
<a href="https://cursor.com/background-agent?bcId=bc-76817d65-56a8-441f-bfb1-2d68c64c4c14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76817d65-56a8-441f-bfb1-2d68c64c4c14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

